### PR TITLE
change shebang line to use bash since the scripts are using bashisms

### DIFF
--- a/src/main/resources/archetype-resources/build-deploy-publish.sh
+++ b/src/main/resources/archetype-resources/build-deploy-publish.sh
@@ -1,4 +1,4 @@
-#[[#!/bin/sh
+#[[#!/bin/bash
 # #%L
 #  wcm.io
 #  %%

--- a/src/main/resources/archetype-resources/build-deploy.sh
+++ b/src/main/resources/archetype-resources/build-deploy.sh
@@ -1,4 +1,4 @@
-#[[#!/bin/sh
+#[[#!/bin/bash
 # #%L
 #  wcm.io
 #  %%

--- a/src/main/resources/archetype-resources/config-definition/packages-upload.sh
+++ b/src/main/resources/archetype-resources/config-definition/packages-upload.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # #%L
 #  wcm.io
 #  %%

--- a/src/main/resources/archetype-resources/content-packages/conf-content/content-download.sh
+++ b/src/main/resources/archetype-resources/content-packages/conf-content/content-download.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # #%L
 #  wcm.io
 #  %%

--- a/src/main/resources/archetype-resources/content-packages/conf-content/content-upload.sh
+++ b/src/main/resources/archetype-resources/content-packages/conf-content/content-upload.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # #%L
 #  wcm.io
 #  %%

--- a/src/main/resources/archetype-resources/content-packages/sample-content/content-download.sh
+++ b/src/main/resources/archetype-resources/content-packages/sample-content/content-download.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # #%L
 #  wcm.io
 #  %%

--- a/src/main/resources/archetype-resources/content-packages/sample-content/content-upload.sh
+++ b/src/main/resources/archetype-resources/content-packages/sample-content/content-upload.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # #%L
 #  wcm.io
 #  %%

--- a/src/main/resources/archetype-resources/content-packages/ui.apps/content-download.sh
+++ b/src/main/resources/archetype-resources/content-packages/ui.apps/content-download.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # #%L
 #  wcm.io
 #  %%

--- a/src/main/resources/archetype-resources/content-packages/ui.apps/content-upload.sh
+++ b/src/main/resources/archetype-resources/content-packages/ui.apps/content-upload.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # #%L
 #  wcm.io
 #  %%


### PR DESCRIPTION
# Intro

The build scripts are using `#!/bin/sh` as shebang line.

The shebang line tells the system which shell to use. sh is dash. On windows systems using Git Bash, the /bin/sh is mapped to a bash shell. That's why windows users don't run into problems with it.

Generally speaking bash is a enhanced sh.

# Why change it?

When running these scripts on a linux machine with `./build-deploy.sh` the shebang line will be interpreted and /bin/sh will execute the script.

The script contains at least two "bashisms" resulting in errors on the command line. More infos about bashims: https://mywiki.wooledge.org/Bashism

Example log output:
```
# created by if [[ $0 == *":\\"* ]]; then
./build-deploy.sh: 33: ./build-deploy.sh: [[: not found

# -e is not properly used in dash, so it is displayed in the log. created by echo -e "*** \e[1mBuild+Deploy complete\e[0m ***"
-e *** Build+Deploy complete ***
```
The `[[ condition ]]` and `echo -e` are not supported by dash.