### PR TITLE
add execution duration display to build-deploy.sh

### DIFF
--- a/src/main/resources/archetype-resources/build-deploy.sh
+++ b/src/main/resources/archetype-resources/build-deploy.sh
@@ -153,6 +153,9 @@ completion_message() {
   fi
   echo ""
 
+  ELAPSED_TIME=$(($SECONDS - $START_TIME))
+  echo "duration: $(($ELAPSED_TIME/60)) min $(($ELAPSED_TIME%60)) sec"
+
   pause_message
 }
 
@@ -213,6 +216,9 @@ exit_with_error() {
 }
 
 ####
+
+# saving time for displaying execution duration
+START_TIME=$SECONDS
 
 parse_parameters "$@"
 welcome_message


### PR DESCRIPTION
I propose to add a duration display to the end of the build script, so one can see how long it took to build+deploy or deploy the application.

This can also signal the user if new changes introduce a longer build time, so one could potentially fix a too long build.

Example for such a message:

```
[INFO] Check bundle activation status...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 38.199 s
[INFO] Finished at: 2019-03-05T15:15:22+01:00
[INFO] ------------------------------------------------------------------------

*** Build+Deploy complete ***

duration: 2 min 24 sec
```

The last maven time only shows the deploy time. the build time is missing. the duration also takes the build time into consideration.