### PR TITLE
refine execution duration display in build-deploy.sh for single digit seconds

### DIFF
--- a/src/main/resources/archetype-resources/build-deploy.sh
+++ b/src/main/resources/archetype-resources/build-deploy.sh
@@ -144,7 +144,7 @@ welcome_message() {
 
 completion_message() {
   ELAPSED_TIME=$(($SECONDS - $START_TIME))
-  TOTAL_TIME="($(($ELAPSED_TIME/60)):$(($ELAPSED_TIME%60)) min)"
+  TOTAL_TIME="($(($ELAPSED_TIME/60)):$(printf "%02d" $(($ELAPSED_TIME%60))) min)"
 
   echo ""
   if [ "$BUILD" = true ] && [ "$DEPLOY" = true ]; then


### PR DESCRIPTION
In #2 I added a build time duration display to build-deploy.sh

This has a small issue when the seconds is a single digit. For example execute following on the terminal:

```
ELAPSED_TIME=64
echo $(($ELAPSED_TIME/60)):$(($ELAPSED_TIME%60))

# result is: 1:4
```

Using printf to add a leading zero:

```
ELAPSED_TIME=64
echo $(($ELAPSED_TIME/60)):$(printf "%02d" $(($ELAPSED_TIME%60)))

# result is: 1:04

ELAPSED_TIME=89
echo $(($ELAPSED_TIME/60)):$(printf "%02d" $(($ELAPSED_TIME%60)))

# result is: 1:29
```