### PR TITLE
Align url handler externalizer's rewriteElements config for FileVault layout to the state of Sling-Initial content layout.

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,9 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
-    <release version="2.1.6" date="not released">
+    <release version="2.1.5" date="not released">
       <action type="update" dev="sseifert">
         Update dependencies.
+      </action>
+      <action type="update" dev="bdang">
+        Align url handler externalizer's rewriteElements config for FileVault layout to the state of Sling-Initial content layout.
       </action>
     </release>
 

--- a/src/main/resources/archetype-resources/content-packages/ui.apps/jcr_root/apps/__projectName__/config/rewriter/rewriter-html/.content.xml
+++ b/src/main/resources/archetype-resources/content-packages/ui.apps/jcr_root/apps/__projectName__/config/rewriter/rewriter-html/.content.xml
@@ -10,7 +10,7 @@
     transformerTypes="[wcm-io-urlhandler-externalizer]">
     <transformer-wcm-io-urlhandler-externalizer
         jcr:primaryType="nt:unstructured"
-        rewriteElements="[img:src,link:href,script:src,use:xlink:href]"/>
+        rewriteElements="[a:href,img:src,link:href,script:src,use:xlink:href]"/>
     <generator-htmlparser
         jcr:primaryType="nt:unstructured"
         includeTags="[A,/A,IMG,AREA,FORM,BASE,LINK,SCRIPT,BODY,/BODY,USE,/USE]"/>


### PR DESCRIPTION
When setting up a project with FileVault layout the a:href is missing which is set for SlingInitial content projects.

See https://github.com/wcm-io/wcm-io-maven-archetype-aem/blob/develop/src/main/resources/archetype-resources/bundles/core/src/main/webapp/app-config/rewriter/rewriter-html.json#L34