### PR TITLE
Build exact sourcemaps for scss to css files

### DIFF
--- a/src/main/resources/archetype-resources/frontend/config/webpack/base/tasks/scss.js
+++ b/src/main/resources/archetype-resources/frontend/config/webpack/base/tasks/scss.js
@@ -12,7 +12,23 @@ export const scss = {
     rules: [
       {
         test: /\.(sa|sc|c)ss$/,
-        use: [MiniCssExtractPlugin.loader, "css-loader", "sass-loader"]
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader
+          },
+          {
+            loader: "css-loader",
+            options: {
+              sourceMap: true
+            }
+          },
+          {
+            loader: "sass-loader",
+            options: {
+              sourceMap: true
+            }
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
To see the exact sources (via source-maps) for *.scss files which will be compiled to css files I've added the following changes