### PR TITLE
Allow deployments with artifacts from artifact manager

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -30,6 +30,9 @@
       <action type="update" dev="sseifert">
         Update dependencies.
       </action>
+      <action type="fix" dev="twolfart">
+        Allow deployment with cleaned config-definition.
+      </action>
     </release>
 
     <release version="3.2.6" date="2020-09-27">

--- a/src/main/resources/archetype-resources/build-deploy.sh
+++ b/src/main/resources/archetype-resources/build-deploy.sh
@@ -217,7 +217,7 @@ execute_deploy() {
     MAVEN_ARGS+="-Dsling.password=${SLING_PASSWORD} "
   fi
 
-  mvn $MAVEN_ARGS -f config-definition conga-aem:package-install
+  mvn $MAVEN_ARGS -f config-definition compile conga-aem:package-install
 
   if [ "$?" -ne "0" ]; then
     exit_with_error "*** DEPLOY FAILED ***"


### PR DESCRIPTION
Currently the deployment from a freshly checked out project does not work, at least config-definition needs to be built locally.