### PR TITLE
remove apps-repository-structure README.md reference

### DIFF
--- a/src/main/resources/archetype-resources/README.md
+++ b/src/main/resources/archetype-resources/README.md
@@ -78,7 +78,6 @@ Modules of this project:
   * HTML client libraries with JavaScript and CSS
   * i18n
 #end
-* [content-packages/apps-repository-structure](content-packages/apps-repository-structure/): AEM content package defining root paths for application package validation
 * [content-packages/complete](content-packages/complete/): AEM content package containing all OSGi bundles of the application and their dependencies
 #if ( $optionEditableTemplates == "y" )
 * [content-packages/conf-content](content-packages/conf-content/): AEM content package with editable templates stored at `/conf`


### PR DESCRIPTION
it was removed in https://github.com/wcm-io/wcm-io-maven-archetype-aem/commit/bb2eb3cffe57eefe0360f846f3b8b3d8a45fe637

so we should delete the README.md reference.

Where do we define new repo roots now? Is this the place for it? https://github.com/wcm-io/wcm-io-maven-archetype-aem/blob/develop/src/main/resources/archetype-resources/config-definition/src/main/templates/__projectName__-aem-cms/__projectName__-aem-cms-config.provisioning.hbs#L97