### PR TITLE
Configure Mockito instrumentation for inline mocking

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -29,6 +29,9 @@
         Switch to Java 17.
       </action>
       <action type="update" dev="sseifert">
+        Configure Mockito instrumentation for inline mocking.
+      </action>
+      <action type="update" dev="sseifert">
         Update dependencies.
       </action>
     </release>

--- a/changes.xml
+++ b/changes.xml
@@ -28,7 +28,7 @@
       <action type="update" dev="sseifert">
         Switch to Java 17.
       </action>
-      <action type="update" dev="sseifert">
+      <action type="update" dev="sseifert" issue="317">
         Configure Mockito instrumentation for inline mocking.
       </action>
       <action type="update" dev="sseifert">

--- a/src/main/resources/archetype-resources/parent/pom.xml
+++ b/src/main/resources/archetype-resources/parent/pom.xml
@@ -1,3 +1,6 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -514,7 +517,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
+          <argLine>-javaagent:${symbol_dollar}{org.mockito:mockito-core:jar}</argLine>
         </configuration>
       </plugin>
 

--- a/src/main/resources/archetype-resources/parent/pom.xml
+++ b/src/main/resources/archetype-resources/parent/pom.xml
@@ -496,6 +496,29 @@
   </dependencyManagement>
 
   <build>
+    <plugins>
+
+      <!-- Configure Mockito instrumentation for inline mocking -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>properties</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
+        </configuration>
+      </plugin>
+
+    </plugins>
     <pluginManagement>
       <plugins>
 


### PR DESCRIPTION
Intenion: implement a solution to avoid this mockito warning:
```
Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3
WARNING: A Java agent has been loaded dynamically (C:\Dev\maven_repository\net\bytebuddy\byte-buddy-agent\1.17.7\byte-buddy-agent-1.17.7.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
```

see https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3